### PR TITLE
使用网易云外链播放器作为BGM播放器

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,10 @@
   </head>
 
   <body>
-    <embed src="audio/BGM.mp3" width="0" height="0"></embed>
+    <div class="bg-music">
+      <iframe frameborder="no" border="0" marginwidth="0" marginheight="0" width=0 height=0
+        src="https://music.163.com/outchain/player?type=2&id=444267215&auto=1&height=66"></iframe>
+    </div>
     <div class="container">
       <div class="row">
         <div class="col-sm-12">


### PR DESCRIPTION
删除了仓库中原有的音频文件。但请注意：
- 在Google Chrome上，BGM可能无法自动播放！
- 在Microsoft Edge上，BGM能够正常播放
- Mozilla FireFox与Internet Explorer未测试